### PR TITLE
Fix the X-Signature format to original cqhttp

### DIFF
--- a/src/main/kotlin/tech/mihoyo/mirai/web/http/ReportService.kt
+++ b/src/main/kotlin/tech/mihoyo/mirai/web/http/ReportService.kt
@@ -144,7 +144,7 @@ class ReportService(
 
     private fun getSha1Hash(botId: Long, content: String): String {
         sha1UtilByBot[botId]?.apply {
-            return this.doFinal(content.toByteArray()).fold("", { str, it -> str + "%02x".format(it) })
+            return "sha1=" + this.doFinal(content.toByteArray()).fold("", { str, it -> str + "%02x".format(it) })
         }
         return ""
     }


### PR DESCRIPTION
无伤大雅 
但是个人使用cqhttp时 req.headers['x-signature'] 的格式是有 “sha1=” 前缀的，个人不会Kotlin，想当然加了个字符串连接，但感觉也不是十分恰当。
如有错误，请指出。
谢谢。